### PR TITLE
Add API to start and stop specific instance/port

### DIFF
--- a/src/fakeredis_common.hrl
+++ b/src/fakeredis_common.hrl
@@ -7,12 +7,12 @@
 %% Seems to give too long lines:
 %% -define(LOG(X),    io:format(user, "[~p:L~p] " ++ X ++ "~n", [?MODULE, ?LINE])).
 
--define(DBG(X),    io:format(user, X ++ "~n", [])).
--define(DBG(X, V), io:format(user, X ++ "~n", V)).
--define(LOG(X),    io:format(user, X ++ "~n", [])).
--define(LOG(X, V), io:format(user, X ++ "~n", V)).
--define(ERR(X),    io:format(user, "Error:" ++ X ++ "~n", [])).
--define(ERR(X, V), io:format(user, "Error:" ++ X ++ "~n", V)).
+-define(DBG(X),    io:format(user, "\033[33mDBG: " ++ X ++ "\033[0m~n", [])).
+-define(DBG(X, V), io:format(user, "\033[33mDBG: " ++ X ++ "\033[0m~n", V)).
+-define(LOG(X),    io:format(user, "LOG: " ++ X ++ "\033[0m~n", [])).
+-define(LOG(X, V), io:format(user, "LOG: " ++ X ++ "\033[0m~n", V)).
+-define(ERR(X),    io:format(user, "\033[31mERR: " ++ X ++ "\033[0m~n", [])).
+-define(ERR(X, V), io:format(user, "\033[31mERR: " ++ X ++ "\033[0m~n", V)).
 
 -else.
 

--- a/src/fakeredis_instance.erl
+++ b/src/fakeredis_instance.erl
@@ -73,8 +73,8 @@ handle_info(E, State) ->
     ?ERR("unexpected: ~p (State: ~p)", [E, State]),
     {noreply, State}.
 
-terminate(_Reason, _Tab) ->
-    ?DBG("fakeredis_intance terminated"),
+terminate(Reason, _Tab) ->
+    ?DBG("fakeredis_intance:terminate(Reason=~p)", [Reason]),
     ok.
 
 code_change(_OldVersion, Tab, _Extra) -> {ok, Tab}.

--- a/src/fakeredis_instance_sup.erl
+++ b/src/fakeredis_instance_sup.erl
@@ -24,7 +24,7 @@ start_link(Port, Options, MaxClients) ->
 
 init([Port, Options, MaxClients]) ->
     ?LOG("Start listening on port=~p [Options=~p MaxClients=~p]", [Port, Options, MaxClients]),
-    {ok, ListenSocket} = gen_tcp:listen(Port, ?TCP_OPTIONS),
+    ListenSocket = start_listen_socket(Port, ?TCP_OPTIONS),
 
     spawn_link(fun() -> start_listeners(Port, MaxClients) end),
 
@@ -37,6 +37,11 @@ init([Port, Options, MaxClients]) ->
     {ok, {SupFlags, ChildSpecs}}.
 
 %% internal functions
+start_listen_socket(Port, Options) ->
+    case gen_tcp:listen(Port, Options) of
+        {ok, ListenSocket} -> ListenSocket;
+        {error, Reason} -> exit({listen_err, Reason})
+    end.
 
 start_listener(Port) ->
     supervisor:start_child(?SERVER(Port), []).


### PR DESCRIPTION
Simulate a crash of a instance, and start it again