### PR TITLE
Move slots, delay per command, event log disconnects

### DIFF
--- a/src/fakeredis_cluster.erl
+++ b/src/fakeredis_cluster.erl
@@ -113,9 +113,10 @@ main_(Ports) ->
 %% Internals
 
 %% Called by fakeredis_instance
--spec log_event(connect, map())      -> ok;
-               (command, [binary()]) -> ok;
-               (reply, any())        -> ok.
+-spec log_event(connect, map())                       -> ok;
+               (disconnect, normal | {error, term()}) -> ok;
+               (command, [binary()])                  -> ok;
+               (reply, any())                         -> ok.
 log_event(EventType, Data) ->
     %% A hash of the caller's pid uniquely represents a connection
     ConnectionId = binary:part(

--- a/test/fakeredis_cluster_SUITE.erl
+++ b/test/fakeredis_cluster_SUITE.erl
@@ -56,7 +56,6 @@ t_cluster_slots(Config) when is_list(Config) ->
 
     %% Restart instance
     fakeredis_cluster:start_instance(30001),
-    fakeredis_cluster:start_instance(30001),
     {ok, Sock2} = gen_tcp:connect("localhost", 30001,
                                  [binary, {active , false}, {packet, 0}]),
     ok = gen_tcp:send(Sock2, Data),
@@ -64,12 +63,15 @@ t_cluster_slots(Config) when is_list(Config) ->
     ok = gen_tcp:close(Sock2),
 
     %% Check event log, mostly to check that the event log functionality works.
+    timer:sleep(100),
     ?assertMatch([{Connection1, connect, _},
                   {Connection1, command, [<<"cluster">>, <<"slots">>]},
                   {Connection1, reply, _},
                   {Connection2, connect, _},
                   {Connection2, command, [<<"cluster">>, <<"slots">>]},
-                  {Connection2, reply, _}],
+                  {Connection2, reply, _},
+                  {Connection2, disconnect, normal}
+                 ],
                  fakeredis_cluster:get_event_log()),
     ok = fakeredis_cluster:clear_event_log(),
     [] = fakeredis_cluster:get_event_log().


### PR DESCRIPTION
* Add move_all_slots/0, moving all slots to a different node
  * The client will get a MOVED redirect which make it refresh the slots mappings.
* Allow configuring delay per command
  * E.g. configuring a longer delay for CLUSTER commands makes it possible to test that a client can handle MOVED redirects without waiting for refresh slot mapping to be complete.
* Log disconnects in event log
  * Makes it possible to test that unused pools are disconnected after refresh slots mapping.